### PR TITLE
Added kube version and defaulted to v1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2019-02-27
+### Added
+- Base EKS module for deployment of Kubernetes cluster v1.10
+- Proxy configuration to allow EKS cluster to operate in private VPC environment
+- Pining versions
+- This CHANGELOG file

--- a/examples/desktop_private_vpc/main.tf
+++ b/examples/desktop_private_vpc/main.tf
@@ -13,7 +13,7 @@ module "eks" {
   http_proxy                      = "${var.http_proxy}"
   no_proxy                        = "${var.no_proxy}"
   key_name                        = "${var.key_name}"
-  desired_worker_nodes            = 1
+  desired_worker_nodes            = "${var.desired_worker_nodes}"
   aws_authenticator_env_variables = "${local.aws_authenticator_env_variables}"
   tags                            = "${local.tags}"
 }

--- a/examples/desktop_private_vpc/variables.tf
+++ b/examples/desktop_private_vpc/variables.tf
@@ -15,3 +15,5 @@ variable "http_proxy" {}
 variable "no_proxy" {}
 
 variable "key_name" {}
+
+variable "desired_worker_nodes" {}

--- a/locals.tf
+++ b/locals.tf
@@ -19,7 +19,7 @@ locals {
       type = "daemonset"
     },
     {
-      name = "coredns"
+      name = "kube-dns"
       type = "deployment"
     },
     {

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,7 @@ module "eks" {
   kubeconfig_aws_authenticator_env_variables = "${var.aws_authenticator_env_variables}"
   worker_group_count                         = "1"
   worker_additional_security_group_ids       = ["${aws_security_group.all_worker_mgmt.id}"]
+  cluster_version                            = "${var.cluster_version}"
 }
 
 resource "aws_security_group" "all_worker_mgmt" {

--- a/variables.tf
+++ b/variables.tf
@@ -64,3 +64,8 @@ variable "tags" {
   type        = "map"
   default     = {}
 }
+
+variable "cluster_version" {
+  description = "Version of k8s to use (eks version is derived from here)"
+  default     = "1.10"
+}


### PR DESCRIPTION
To allow for horizontal pod scaling, eks platform version 2 or greater must be used. Currently eks.v2 only supports kubernetes v1.10. This will be the default version until later versions are supported.